### PR TITLE
Fetch GitHub API to get release version and assets

### DIFF
--- a/_includes/latest-version.md
+++ b/_includes/latest-version.md
@@ -1,1 +1,0 @@
-{%- assign version = "0.0.12" -%}

--- a/download.md
+++ b/download.md
@@ -8,30 +8,35 @@ title: Download
 
 The latest version of Oriedita is <b id="v"></b> you can download it from this page.
 
-<script src="main.js"></script>
-<script>
-	getReleaseVersion(v => document.getElementById('v').innerText = v);
-</script>
-
 ## Java .jar
 
 Runs on any platform that is supported by Java SE. Make sure you have at least Java 11 installed, you can download Java from [adoptium.net](https://adoptium.net/index.html?variant=openjdk11&jvmVariant=hotspot) or from other trusted Java distributors.
 
-[Download Java .jar](https://github.com/oriedita/oriedita/releases/download/v{{ version }}/origami-editor-{{ version }}.jar){: .btn .btn-download :}
+[Download Java .jar](https://github.com/oriedita/oriedita/releases/download/){: #jar .btn .btn-download :}
 
 ## Windows installer 
 The `.exe` file installs Oriedita on your computer, it adds a shortcut to your start menu and associates `.cp` and `.ori` files to open with Oriedita. The installer brings it's own version of Java which is used only by Oriedita, so you don't have to install it yourself.
 
-[Download Windows Installer](https://github.com/oriedita/oriedita/releases/download/v{{ version }}/Origami.Editor-{{ version }}.exe){: .btn .btn-download :}
+[Download Windows Installer](https://github.com/oriedita/oriedita/releases/download/){: #exe .btn .btn-download :}
 
 ## Windows Portable Executable
 
 The Windows portable executable comes with it's own version of Java, which is used by Oriedita. Use this version if you have problems installing Java on your computer, but don't want to install Oriedita on your computer.
 
-[Download Windows Portable](https://github.com/oriedita/oriedita/releases/download/v{{ version }}/Origami.Editor.Portable.{{ version }}.zip){: .btn .btn-download :}
+[Download Windows Portable](https://github.com/oriedita/oriedita/releases/download/){: #zip .btn .btn-download :}
 
 ## Older versions
 
 Download older releases from the GitHub Releases page.
 
 [Older releases](https://github.com/oriedita/oriedita/releases){: .btn :}
+
+<script src="main.js"></script>
+<script>
+	getRelease(r => {
+		document.getElementById('v').innerText =  version(r);
+		document.getElementById('jar').href = asset(r, 'jar');
+		document.getElementById('exe').href = asset(r, 'exe');
+		document.getElementById('zip').href = asset(r, 'zip');
+	});
+</script>

--- a/download.md
+++ b/download.md
@@ -4,11 +4,14 @@ nav_order: 2
 title: Download
 ---
 
-{%- include latest-version.md -%}
-
 # Download
 
-The latest version of Oriedita is **{{ version }}** you can download it from this page.
+The latest version of Oriedita is <b id="v" class="font-weight-bold"></b> you can download it from this page.
+
+<script src="main.js"></script>
+<script>
+	getReleaseVersion(v => document.getElementById('v').innerText = v);
+</script>
 
 ## Java .jar
 

--- a/download.md
+++ b/download.md
@@ -6,7 +6,7 @@ title: Download
 
 # Download
 
-The latest version of Oriedita is <b id="v" class="font-weight-bold"></b> you can download it from this page.
+The latest version of Oriedita is <b id="v"></b> you can download it from this page.
 
 <script src="main.js"></script>
 <script>

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Oriedita can simulate folding a crease pattern and show if a crease pattern is f
 
 <script src="main.js"></script>
 <script>
-	getReleaseVersion(v => document.getElementById('dl').innerText += ' ' + v);
+	getRelease(r => document.getElementById('dl').innerText += ' ' + version(r));
 </script>
 
 ![](https://i.imgur.com/w1Nh7aC.png)

--- a/index.md
+++ b/index.md
@@ -4,8 +4,6 @@ title: Oriedita
 nav_order: 1
 ---
 
-{%- include latest-version.md -%}
-
 # Oriedita
 
 [_Oriedita is a fork of Orihime オリヒメ and not affiliated with the original version._](./orihime.md)
@@ -15,8 +13,13 @@ Oriedita is a computer program used for drawing origami crease patterns. It come
 Oriedita can simulate folding a crease pattern and show if a crease pattern is flat-foldable, and if it is, show a folded version of the crease pattern.
 
 <span class="fs-8">
-[Download Oriedita {{ version }}](./download.md){: .btn .btn-download :}
+[Download Oriedita](./download.md){: #dl .btn .btn-download :}
 </span>
+
+<script src="main.js"></script>
+<script>
+	getReleaseVersion(v => document.getElementById('dl').innerText += ' ' + v);
+</script>
 
 ![](https://i.imgur.com/w1Nh7aC.png)
 

--- a/main.js
+++ b/main.js
@@ -1,7 +1,13 @@
-async function getReleaseVersion(callback) {
+async function getRelease(callback) {
 	const response = await fetch('https://api.github.com/repos/oriedita/oriedita/releases/latest');
-	const json = await response.json();
+	callback(await response.json());
+}
+
+function version(json) {
 	let version = json.tag_name;
-	version = version.replace(/^v/, '');
-	callback(version);
+	return version.replace(/^v/, '');
+}
+
+function asset(json, ext) {
+	return json.assets.find(a => a.browser_download_url.endsWith(ext))?.browser_download_url;
 }

--- a/main.js
+++ b/main.js
@@ -1,0 +1,7 @@
+async function getReleaseVersion(callback) {
+	const response = await fetch('https://api.github.com/repos/oriedita/oriedita/releases/latest');
+	const json = await response.json();
+	let version = json.tag_name;
+	version = version.replace(/^v/, '');
+	callback(version);
+}


### PR DESCRIPTION
This PR uses GitHub API and JavaScript to dynamically get the version text and the link to assets. It will only have a slight delay on first loading, and afterwards there's basically no delay due to browser caching.